### PR TITLE
Avoid rounding errors in 'Incremental' by only dividing after all multiplications are done

### DIFF
--- a/progress/bar.py
+++ b/progress/bar.py
@@ -64,8 +64,8 @@ class IncrementalBar(Bar):
 
     def update(self):
         nphases = len(self.phases)
-        expanded_length = int(nphases * self.width * self.progress)
-        filled_length = int(self.width * self.progress)
+        expanded_length = int(nphases * self.width * self.index / self.max)
+        filled_length = int(self.width * self.index / self.max)
         empty_length = self.width - filled_length
         phase = expanded_length - (filled_length * nphases)
 


### PR DESCRIPTION
The following example will fail due to a rounding error in `filled_length` calculation:

```python
from progress.bar import IncrementalBar
bar = IncrementalBar(max=78, width=234)
bar.next(5)
```
This PR proposes a solution to the issue.