### PR TITLE
use unicode_literals instead of old unicode specifier

### DIFF
--- a/progress/bar.py
+++ b/progress/bar.py
@@ -14,6 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from __future__ import unicode_literals
 from . import Progress
 from .helpers import WritelnMixin
 
@@ -45,22 +46,22 @@ class ChargingBar(Bar):
     suffix = '%(percent)d%%'
     bar_prefix = ' '
     bar_suffix = ' '
-    empty_fill = u'∙'
-    fill = u'█'
+    empty_fill = '∙'
+    fill = '█'
 
 
 class FillingSquaresBar(ChargingBar):
-    empty_fill = u'▢'
-    fill = u'▣'
+    empty_fill = '▢'
+    fill = '▣'
 
 
 class FillingCirclesBar(ChargingBar):
-    empty_fill = u'◯'
-    fill = u'◉'
+    empty_fill = '◯'
+    fill = '◉'
 
 
 class IncrementalBar(Bar):
-    phases = (u' ', u'▏', u'▎', u'▍', u'▌', u'▋', u'▊', u'▉', u'█')
+    phases = (' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█')
 
     def update(self):
         nphases = len(self.phases)
@@ -80,4 +81,4 @@ class IncrementalBar(Bar):
 
 
 class ShadyBar(IncrementalBar):
-    phases = (u' ', u'░', u'▒', u'▓', u'█')
+    phases = (' ', '░', '▒', '▓', '█')

--- a/progress/counter.py
+++ b/progress/counter.py
@@ -14,6 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from __future__ import unicode_literals
 from . import Infinite, Progress
 from .helpers import WriteMixin
 
@@ -34,7 +35,7 @@ class Countdown(WriteMixin, Progress):
 
 
 class Stack(WriteMixin, Progress):
-    phases = (u' ', u'▁', u'▂', u'▃', u'▄', u'▅', u'▆', u'▇', u'█')
+    phases = (' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█')
     hide_cursor = True
 
     def update(self):
@@ -44,4 +45,4 @@ class Stack(WriteMixin, Progress):
 
 
 class Pie(Stack):
-    phases = (u'○', u'◔', u'◑', u'◕', u'●')
+    phases = ('○', '◔', '◑', '◕', '●')

--- a/progress/spinner.py
+++ b/progress/spinner.py
@@ -14,6 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from __future__ import unicode_literals
 from . import Infinite
 from .helpers import WriteMixin
 
@@ -29,12 +30,12 @@ class Spinner(WriteMixin, Infinite):
 
 
 class PieSpinner(Spinner):
-    phases = [u'◷', u'◶', u'◵', u'◴']
+    phases = ['◷', '◶', '◵', '◴']
 
 
 class MoonSpinner(Spinner):
-    phases = [u'◑', u'◒', u'◐', u'◓']
+    phases = ['◑', '◒', '◐', '◓']
 
 
 class LineSpinner(Spinner):
-    phases = [u'⎺', u'⎻', u'⎼', u'⎽', u'⎼', u'⎻']
+    phases = ['⎺', '⎻', '⎼', '⎽', '⎼', '⎻']


### PR DESCRIPTION
this brings Python 3.2 compatibility