### PR TITLE
Implement background spinners

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,16 @@ For actions with an unknown number of steps you can use a spinner. ::
         # Do some work
         spinner.next()
 
+Spinners can run in the background, for example, during a long, blocking
+call. They will automatically be advanced with a customizable frequency
+controlled by the ``frequency`` keyword argument (0.1 seconds by default)
+This behvaior is available using the ``with`` statement. ::
+
+    from progress.spinner import Spinner
+
+    with Spinner('Loading ', frequency=0.1):
+        # Do some work, or make a blocking call
+
 There are 4 predefined spinners:
 
 - Spinner

--- a/test_progress.py
+++ b/test_progress.py
@@ -37,3 +37,7 @@ for i in range(100):
     bar.goto(randint(0, 100))
     sleep(0.1)
 bar.finish()
+
+with Spinner('ThreadedSpinner '):
+    sleep(3)
+print()


### PR DESCRIPTION
Using threading and a context manager, automatically advance a
spinner at a customizable frequency during a context, removing
some of the administrivia of running a spinner and enabling a
spinner to run during blocking calls
- Implement context manager methods in Infinite
- Add a threaded spinner to the tests
- Add documentation
