### PR TITLE
Now iter() calls finish even on an exception

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -73,10 +73,12 @@ class Infinite(object):
         self.update()
 
     def iter(self, it):
-        for x in it:
-            yield x
-            self.next()
-        self.finish()
+        try:
+            for x in it:
+                yield x
+                self.next()
+        finally:
+            self.finish()
 
 
 class Progress(Infinite):
@@ -117,7 +119,9 @@ class Progress(Infinite):
         except TypeError:
             pass
 
-        for x in it:
-            yield x
-            self.next()
-        self.finish()
+        try:
+            for x in it:
+                yield x
+                self.next()
+        finally:
+            self.finish()


### PR DESCRIPTION
As I reported in issue #14 raising an exception in a loop over a
iterator got from a iter() call will not finalize the bar.

This commit uses a try, finally block to ensure that finish is always
called