### PR TITLE
Allow usage as a context manager.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,17 @@ To use them, just call ``next`` to advance and ``finish`` to finish:
         bar.next()
     bar.finish()
 
+or use any bar of this class as a context manager:
+
+.. code-block:: python
+
+    from progress.bar import Bar
+
+    with Bar('Processing', max=20) as bar:
+        for i in range(20):
+            # Do some work
+            bar.next()
+
 The result will be a bar like the following: ::
 
     Processing |#############                   | 42/100

--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -73,12 +73,17 @@ class Infinite(object):
         self.update()
 
     def iter(self, it):
-        try:
+        with self:
             for x in it:
                 yield x
                 self.next()
-        finally:
-            self.finish()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.finish()
 
 
 class Progress(Infinite):
@@ -119,9 +124,7 @@ class Progress(Infinite):
         except TypeError:
             pass
 
-        try:
+        with self:
             for x in it:
                 yield x
                 self.next()
-        finally:
-            self.finish()

--- a/test_progress.py
+++ b/test_progress.py
@@ -27,9 +27,10 @@ for bar_cls in (Bar, ChargingBar, FillingSquaresBar, FillingCirclesBar):
 
 for bar_cls in (IncrementalBar, PixelBar, ShadyBar):
     suffix = '%(percent)d%% [%(elapsed_td)s / %(eta)d / %(eta_td)s]'
-    bar = bar_cls(bar_cls.__name__, suffix=suffix)
-    for i in bar.iter(range(200)):
-        sleep()
+    with bar_cls(bar_cls.__name__, suffix=suffix, max=200) as bar:
+        for i in range(200):
+            bar.next()
+            sleep()
 
 for spin in (Spinner, PieSpinner, MoonSpinner, LineSpinner, PixelSpinner):
     for i in spin(spin.__name__ + ' ').iter(range(100)):


### PR DESCRIPTION
Using a context manager you get exception management for free. I adjusted iter() and one of the samples to use the context manager.

Regarding iter() - would it be valuable to also make the non-infinite classes iterable themselves?

This would allow code like this:

```
for i in Bar(max=100):
    # Do something with i
    sleep()
```

PS: You should probably deprecate the SigIntMixin, since it isn't useful with proper exception handling (IMHO).
PPS: This is half of #11, without all the threading...
