### PR TITLE
Added property long_eta

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -63,6 +63,10 @@ class Infinite(object):
     @property
     def elapsed_td(self):
         return timedelta(seconds=self.elapsed)
+    
+    @property
+    def long_avg(self):#Gets the total average instead of just the running average
+        return self.elapsed/self.index
 
     def update_avg(self, n, dt):
         if n > 0:
@@ -135,6 +139,10 @@ class Progress(Infinite):
     @property
     def eta_td(self):
         return timedelta(seconds=self.eta)
+    
+    @property
+    def long_eta(self): #For long running tasks the total average is more stable
+        int(ceil(self.long_avg * self.remaining))
 
     @property
     def percent(self):


### PR DESCRIPTION
For tasks that run hours not seconds, a total average eta generally becomes more stable and accurate as the task progresses.

A small running average does the unstable "windows file transfer" sort of estimate where the estimated time is wildly unstable, whereas a long running average starts unstable and then converges to an ok approximation.