### PR TITLE
Add additional help when AttributeError is raised with regards check_tty 

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -109,7 +109,10 @@ class Infinite(object):
                 print(SHOW_CURSOR, end='', file=self.file)
 
     def is_tty(self):
-        return self.file.isatty() if self.check_tty else True
+        try:
+            return self.file.isatty() if self.check_tty else True
+        except AttributeError:
+            raise AttributeError('\'{}\' object has no attribute \'isatty\'. Try setting parameter check_tty=False.'.format(self))
 
     def next(self, n=1):
         now = monotonic()


### PR DESCRIPTION
In reference to issue #52 I thought it might be useful to include an error message for people to try setting check_tty=False so this question doesn't have to be re-answered.