### PR TITLE
avoid division by 0

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -158,6 +158,9 @@ class Progress(Infinite):
 
     @property
     def progress(self):
+        # avoid division by 0
+        if self.max == 0:
+            return 0
         return min(1, self.index / self.max)
 
     @property


### PR DESCRIPTION
This fixes an issue that arises when an empty list is passed to the `iter()` method. 

Currently, the following example raises a `ZeroDivisionError`:
```python
from progress.bar import Bar

it = []

bar = Bar("test")
for elem in bar.iter(it):
    pass
```