### PR TITLE
progress: avoid division by zero

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -158,6 +158,8 @@ class Progress(Infinite):
 
     @property
     def progress(self):
+        if self.max == 0:
+            return 0
         return min(1, self.index / self.max)
 
     @property


### PR DESCRIPTION
This occurs otherwise with `bar.iter([])`.