### PR TITLE
Reduce printing in tight loops

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -37,7 +37,7 @@ class Infinite(object):
     check_tty = True
     hide_cursor = True
 
-    def __init__(self, message='', **kwargs):
+    def __init__(self, message='', print_dt = .500,**kwargs):
         self.index = 0
         self.start_ts = monotonic()
         self.avg = 0
@@ -49,6 +49,8 @@ class Infinite(object):
 
         self._width = 0
         self.message = message
+        self.print_dt = print_dt
+        self._prev_write = self.start_ts - self.print_dt * 2
 
         if self.file and self.is_tty():
             if self.hide_cursor:
@@ -92,6 +94,10 @@ class Infinite(object):
             print('\r\x1b[K', end='', file=self.file)
 
     def write(self, s):
+        now = monotonic()
+        if now self.prev_write < self._print_dt:
+            return
+        self.prev_write = now
         if self.file and self.is_tty():
             line = self.message + s.ljust(self._width)
             print('\r' + line, end='', file=self.file)

--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -95,9 +95,9 @@ class Infinite(object):
 
     def write(self, s):
         now = monotonic()
-        if now self.prev_write < self._print_dt:
+        if now - self._prev_write < self.print_dt:
             return
-        self.prev_write = now
+        self._prev_write = now
         if self.file and self.is_tty():
             line = self.message + s.ljust(self._width)
             print('\r' + line, end='', file=self.file)


### PR DESCRIPTION
Printing is slow, which is an issue for big tight loops (~100k items, at 100 items/second).
These changes reduce the printing to, at most, twice per second by default.
Setting print_dt = -1  will preserve the previous behaviour.