### PR TITLE
Make hide & show cursor feature platform independent (add Windows support)

### DIFF
--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -101,7 +101,7 @@ class Infinite(object):
 
     def finish(self):
         if self.file and self.is_tty():
-            print(file=self.file)
+            print(flush = True, file=self.file)
             if self._hidden_cursor:
                 cursor.show()
                 self._hidden_cursor = False

--- a/progress/__init__.py
+++ b/progress/__init__.py
@@ -18,6 +18,7 @@ from collections import deque
 from datetime import timedelta
 from math import ceil
 from sys import stderr
+import cursor
 try:
     from time import monotonic
 except ImportError:
@@ -25,9 +26,6 @@ except ImportError:
 
 
 __version__ = '1.6'
-
-HIDE_CURSOR = '\x1b[?25l'
-SHOW_CURSOR = '\x1b[?25h'
 
 
 class Infinite(object):
@@ -52,13 +50,13 @@ class Infinite(object):
 
         if self.file and self.is_tty():
             if self.hide_cursor:
-                print(HIDE_CURSOR, end='', file=self.file)
+                cursor.hide()
                 self._hidden_cursor = True
         self.writeln('')
 
     def __del__(self):
         if self._hidden_cursor:
-            print(SHOW_CURSOR, end='', file=self.file)
+            cursor.show()
 
     def __getitem__(self, key):
         if key.startswith('_'):
@@ -105,7 +103,7 @@ class Infinite(object):
         if self.file and self.is_tty():
             print(file=self.file)
             if self._hidden_cursor:
-                print(SHOW_CURSOR, end='', file=self.file)
+                cursor.show()
                 self._hidden_cursor = False
 
     def is_tty(self):


### PR DESCRIPTION
The VT100 control sequences used to  hide & show the cursor are not fully supported by Windows.

New method uses the "cursor" package. On Windows platforms, it uses the Windows API. On Posix platforms, it uses the same VT100 sequences.